### PR TITLE
Handle empty XML elements and unit test.

### DIFF
--- a/Sources/XMLCoding/XMLStackParser.swift
+++ b/Sources/XMLCoding/XMLStackParser.swift
@@ -183,7 +183,8 @@ internal class _XMLElement {
                     } else {
                         node[childElement.key] = newValue
                     }
-                } else {
+                // if the node is empty and there is no existing value
+                } else if node[childElement.key] == nil {
                     // an empty node can be treated as an empty dictionary
                     node[childElement.key] = [:]
                 }

--- a/Sources/XMLCoding/XMLStackParser.swift
+++ b/Sources/XMLCoding/XMLStackParser.swift
@@ -183,6 +183,9 @@ internal class _XMLElement {
                     } else {
                         node[childElement.key] = newValue
                     }
+                } else {
+                    // an empty node can be treated as an empty dictionary
+                    node[childElement.key] = [:]
                 }
             }
         }

--- a/Tests/XMLCodingTests/XMLParsingTests.swift
+++ b/Tests/XMLCodingTests/XMLParsingTests.swift
@@ -3,15 +3,53 @@ import XCTest
 
 
 class XMLParsingTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-//        XCTAssertEqual(XMLParsing().text, "Hello, World!")
+    struct Result: Codable {
+        let message: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case message = "Message"
+        }
+    }
+    
+    struct Metadata: Codable {
+        let id: String
+        
+        enum CodingKeys: String, CodingKey {
+            case id = "Id"
+        }
+    }
+    
+    struct Response: Codable {
+        let result: Result
+        let metadata: Metadata
+        
+        enum CodingKeys: String, CodingKey {
+            case result = "Result"
+            case metadata = "Metadata"
+        }
+    }
+    
+    func testEmptyElement() throws {
+        let inputString = """
+            <Response>
+                <Result/>
+                <Metadata>
+                    <Id>id</Id>
+                </Metadata>
+            </Response>
+            """
+        
+        guard let inputData = inputString.data(using: .utf8) else {
+            return XCTFail()
+        }
+        
+        let response = try XMLDecoder().decode(Response.self, from: inputData)
+        
+        XCTAssertNil(response.result.message)
     }
 
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testEmptyElement", testEmptyElement),
     ]
 }

--- a/Tests/XMLCodingTests/XMLParsingTests.swift
+++ b/Tests/XMLCodingTests/XMLParsingTests.swift
@@ -72,5 +72,6 @@ class XMLParsingTests: XCTestCase {
 
     static var allTests = [
         ("testEmptyElement", testEmptyElement),
+        ("testEmptyElementNotEffectingPreviousElement", testEmptyElementNotEffectingPreviousElement),
     ]
 }

--- a/Tests/XMLCodingTests/XMLParsingTests.swift
+++ b/Tests/XMLCodingTests/XMLParsingTests.swift
@@ -48,6 +48,27 @@ class XMLParsingTests: XCTestCase {
         XCTAssertNil(response.result.message)
     }
 
+    func testEmptyElementNotEffectingPreviousElement() throws {
+        let inputString = """
+            <Response>
+                <Result>
+                    <Message>message</Message>
+                </Result>
+                <Result/>
+                <Metadata>
+                    <Id>id</Id>
+                </Metadata>
+            </Response>
+            """
+        
+        guard let inputData = inputString.data(using: .utf8) else {
+            return XCTFail()
+        }
+        
+        let response = try XMLDecoder().decode(Response.self, from: inputData)
+        
+        XCTAssertEqual("message", response.result.message)
+    }
 
     static var allTests = [
         ("testEmptyElement", testEmptyElement),


### PR DESCRIPTION
Currently the flatten() function ignores empty XML Elements but these may be a required property in the object being decoded into that happens to have no required child properties.