### PR TITLE
Add ListEncodingStrategy and ListDecodingStrategy

### DIFF
--- a/Sources/XMLCoding/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoding/Decoder/XMLDecoder.swift
@@ -109,8 +109,9 @@ open class XMLDecoder {
         case preserveStructure
         
         /// Collapse the XML structure to avoid the outer type.
-        /// Useful when individual items will all listed under the one tag and
-        /// the added layer of the outer type is not useful.
+        /// Useful when individual items will all be listed under one tag;
+        /// the outer type will only include one list under this tag and can be
+        /// omitted.
         case collapseListUsingItemTag(String)
     }
     

--- a/Sources/XMLCoding/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoding/Decoder/XMLDecoder.swift
@@ -102,6 +102,18 @@ open class XMLDecoder {
         case convertFromString(positiveInfinity: String, negativeInfinity: String, nan: String)
     }
     
+    /// The strategy to use when decoding lists.
+    public enum ListDecodingStrategy {
+        /// Preserves the XML structure, an outer type will contain lists
+        /// grouped under the tag used for individual items. This is the default strategy.
+        case preserveStructure
+        
+        /// Collapse the XML structure to avoid the outer type.
+        /// Useful when individual items will all listed under the one tag and
+        /// the added layer of the outer type is not useful.
+        case collapseListUsingItemTag(String)
+    }
+    
     /// The strategy to use in decoding dates. Defaults to `.secondsSince1970`.
     open var dateDecodingStrategy: DateDecodingStrategy = .secondsSince1970
     
@@ -111,6 +123,9 @@ open class XMLDecoder {
     /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
     open var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
     
+    /// The strategy to use in decoding lists. Defaults to `.preserveStructure`.
+    open var listDecodingStrategy: ListDecodingStrategy = .preserveStructure
+    
     /// Contextual user-provided information for use during decoding.
     open var userInfo: [CodingUserInfoKey : Any] = [:]
     
@@ -119,6 +134,7 @@ open class XMLDecoder {
         let dateDecodingStrategy: DateDecodingStrategy
         let dataDecodingStrategy: DataDecodingStrategy
         let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
+        let listDecodingStrategy: ListDecodingStrategy
         let userInfo: [CodingUserInfoKey : Any]
     }
     
@@ -127,6 +143,7 @@ open class XMLDecoder {
         return _Options(dateDecodingStrategy: dateDecodingStrategy,
                         dataDecodingStrategy: dataDecodingStrategy,
                         nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy,
+                        listDecodingStrategy: listDecodingStrategy,
                         userInfo: userInfo)
     }
     
@@ -610,4 +627,3 @@ extension _XMLDecoder {
         return decoded
     }
 }
-

--- a/Sources/XMLCoding/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoding/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -28,9 +28,21 @@ internal struct _XMLUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     /// Initializes `self` by referencing the given decoder and container.
     internal init(referencing decoder: _XMLDecoder, wrapping container: [Any]) {
         self.decoder = decoder
-        self.container = container
         self.codingPath = decoder.codingPath
         self.currentIndex = 0
+    
+        switch decoder.options.listDecodingStrategy {
+        case .preserveStructure:
+            self.container = container
+        case .collapseListUsingItemTag(let itemTag):
+            if container.count == 1,
+                let itemKeyMap = container[0] as? [AnyHashable: Any],
+                let list = itemKeyMap[itemTag] as? [Any] {
+                    self.container = list
+            } else {
+                self.container = []
+            }
+        }
     }
     
     // MARK: - UnkeyedDecodingContainer Methods
@@ -362,3 +374,4 @@ internal struct _XMLUnkeyedDecodingContainer : UnkeyedDecodingContainer {
         return _XMLDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
     }
 }
+


### PR DESCRIPTION
Provides an option to more compactly represent a list in a type hierarchy by collapsing a list with all items under a single tag when decoding and expanding all items to be under that tag when encoding. No change to default behavior. Added tests to verify default behavior and behavior with new strategies.