### PR TITLE
XMLHeader updates

### DIFF
--- a/Sources/XMLCoding/XMLStackParser.swift
+++ b/Sources/XMLCoding/XMLStackParser.swift
@@ -24,11 +24,7 @@ public struct XMLHeader {
     /// indicates whetehr a document relies on information from an external source.
     var standalone: String? = nil
     
-    init(version: Double? = nil) {
-        self.version = version
-    }
-    
-    init(version: Double?, encoding: String?, standalone: String? = nil) {
+    public init(version: Double? = nil, encoding: String? = nil, standalone: String? = nil) {
         self.version = version
         self.encoding = encoding
         self.standalone = standalone


### PR DESCRIPTION
Removed unnecessary duplicate XMLHeader.init
Set defaults for params of XMLHeader.init
Made XMLHeader.init public for use outside of module.