### PR TITLE
Added .none the StringEncodingStrategy

### DIFF
--- a/Sources/XMLCoding/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoding/Encoder/XMLEncoder.swift
@@ -64,6 +64,9 @@ open class XMLEncoder {
         
         /// Encoded the `String` as a CData-encoded string.
         case cdata
+        
+        /// Do NOT encode the `String`.
+        case none
     }
     
     /// The strategy to use for encoding `Data` values.
@@ -164,6 +167,7 @@ open class XMLEncoder {
             return result
         }
     }
+
     
     /// The strategy to use for encoding attributes on a node.
     public enum AttributeEncodingStrategy {

--- a/Sources/XMLCoding/XMLStackParser.swift
+++ b/Sources/XMLCoding/XMLStackParser.swift
@@ -91,7 +91,7 @@ internal class _XMLElement {
             throw EncodingError.invalidValue(object, EncodingError.Context(codingPath: [], debugDescription: "Top-level encoded as non-root XML fragment."))
         }
         
-        return element.toXMLString(with: header, withCDATA: options.stringEncodingStrategy != .deferredToString).data(using: .utf8, allowLossyConversion: true)!
+        return element.toXMLString(with: header, withCDATA: options.stringEncodingStrategy == .cdata, ignoreEscaping: options.stringEncodingStrategy == .none).data(using: .utf8, allowLossyConversion: true)!
     }
     
     fileprivate static func createElement(parentElement: _XMLElement?, key: String, object: [String: Container]) {
@@ -196,13 +196,13 @@ internal class _XMLElement {
     
     func toXMLString(with header: XMLHeader? = nil, withCDATA cdata: Bool, ignoreEscaping: Bool = false) -> String {
         if let header = header, let headerXML = header.toXML() {
-            return headerXML + _toXMLString(withCDATA: cdata)
+            return headerXML + _toXMLString(withCDATA: cdata, ignoreEscaping: ignoreEscaping)
         } else {
-            return _toXMLString(withCDATA: cdata)
+            return _toXMLString(withCDATA: cdata, ignoreEscaping: ignoreEscaping)
         }
     }
     
-    fileprivate func _toXMLString(indented level: Int = 0, withCDATA cdata: Bool, ignoreEscaping: Bool = false) -> String {
+    fileprivate func _toXMLString(indented level: Int = 0, withCDATA cdata: Bool, ignoreEscaping: Bool) -> String {
         var string = String(repeating: " ", count: level * 4)
         string += "<\(key)"
         
@@ -223,7 +223,7 @@ internal class _XMLElement {
             
             for childElement in children {
                 for child in childElement.value {
-                    string += child._toXMLString(indented: level + 1, withCDATA: cdata)
+                    string += child._toXMLString(indented: level + 1, withCDATA: cdata, ignoreEscaping: ignoreEscaping)
                     string += "\n"
                 }
             }


### PR DESCRIPTION
Updated _XMLElement.createRootElement to set ignoreEscaping parameter in call to element.toXMLString
Updated toXMLString to pass along ignoreEscaping to _toXMLString
Removed default value for ignoreEscaping in _toXMLString
Changed options.stringEncodingStrategy != .deferredToString to options.stringEncodingStrategy == .cdata to be more explicit.
Added StringEncodingStrategy.none to provide option to user.

 I was having an issue in which a URL String containing query params would encode the "&" to be  "&amp" therefore ruining the URL.  Using StringEncodingStrategy.cdata solved this issue, however, I implemented StringEncodingStrategy.none in order to provide a more human readable alternative.  The logic to ignore encoding was already in place but it was never exposed in the XMLEncoder's API.