### PR TITLE
Fix Swift 5 Build Warnings

### DIFF
--- a/Sources/XMLCoding/Decoder/DecodingErrorExtension.swift
+++ b/Sources/XMLCoding/Decoder/DecodingErrorExtension.swift
@@ -12,7 +12,7 @@ import Foundation
 // Error Utilities
 //===----------------------------------------------------------------------===//
 
-internal extension DecodingError {
+extension DecodingError {
     /// Returns a `.typeMismatch` error describing the expected type.
     ///
     /// - parameter path: The path of `CodingKey`s taken to decode a value of this type.

--- a/Sources/XMLCoding/Encoder/EncodingErrorExtension.swift
+++ b/Sources/XMLCoding/Encoder/EncodingErrorExtension.swift
@@ -11,7 +11,7 @@ import Foundation
 //===----------------------------------------------------------------------===//
 // Error Utilities
 //===----------------------------------------------------------------------===//
-internal extension EncodingError {
+extension EncodingError {
     /// Returns a `.invalidValue` error describing the given invalid floating-point value.
     ///
     ///


### PR DESCRIPTION
Removes redundant access control modifiers on extensions of `DecodingError` and `EncodingError`.